### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python -m http.server"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # html-terminal
 Fork this repository to have your own terminal-looking webpage!
+
+[![Run on Repl.it](https://repl.it/badge/github/CRSpradlin/html-terminal)](https://repl.it/github/CRSpradlin/html-terminal)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@CRSpradlin/html-terminal).